### PR TITLE
Resolve issue: value too great for base

### DIFF
--- a/server_wake_up_schedular.sh
+++ b/server_wake_up_schedular.sh
@@ -22,9 +22,11 @@ current_minutes=${current_time#*:}
 target_hours=${time%%:*}
 target_minutes=${time#*:}
 
+echo "Wakeup planned at $target_hours:$target_minutes"
+
 # Calculate the time difference in seconds
 current_seconds=$((current_hours * 3600 + current_minutes * 60))
-target_seconds=$((target_hours * 3600 + target_minutes * 60))
+target_seconds=$((10#$target_hours * 3600 + 10#$target_minutes * 60))
 time_diff_seconds=$((target_seconds - current_seconds))
 
 # Check if the target time is earlier than the current time (example for next day wake-up)


### PR DESCRIPTION
Following the comment part of the script, "time" needs to be in fomat HH:mm. Therefore there is a chance to have leading "0" which is interpreted as octal value. For example this can happen when value for HH is set to a value 07 < x <10. The interpreter assumes to have a octal value then leading to wrong calculation for rtcwake. Fix forced to interpret values with leading "0" to base 10.